### PR TITLE
Fix whitespace stripping in completion heuristic

### DIFF
--- a/lib/NodeExploitSynthesis/src/synthesis/smt_generator.py
+++ b/lib/NodeExploitSynthesis/src/synthesis/smt_generator.py
@@ -35,12 +35,13 @@ def use_funx_heuristic_aux(completion):
         return completion
     
     if isinstance(completion, str):
+        completion = completion.strip()
         if completion.startswith('return') and completion.endswith(';'):
             return completion[:-1] + '+'
         else:
             return completion
 
-    if completion[0].value.startswith('return'):
+    if completion[0].value.strip().startswith('return'):
         for i in range(len(completion)):
             if isinstance(completion[i], Payload):
                 break
@@ -48,8 +49,8 @@ def use_funx_heuristic_aux(completion):
             return completion
 
         i = i - 1
-        if completion[i].value.endswith(';'):
-            completion[i].value = completion[i].value[:-1] + '+'
+        if completion[i].value.strip().endswith(';'):
+            completion[i].value = completion[i].value.strip()[:-1] + '+'
             
     return completion
 


### PR DESCRIPTION
In `lib/NodeExploitSynthesis/src/synthesis/smt_generator.py:39` `use_funx_heuristic_aux` function, the check for `startswith('return')` does not strip the string, so any function body of `return` statements with whitespaces in front will not be covered by the heuristic. A concrete example is with `accesslog`, where the payload it creates is `\"; global.CTF()//` instead of `\"+global.CTF()//`.

The fix strips the string or the relevant elements in the list before doing the check. For the `accesslog` example, this will create the correct payload but still will fail to confirm exploit since the driver does not call the necessary sequence of events/functions.