### PR TITLE
Fix isExternal flag for native functions via call/apply/bind

### DIFF
--- a/src/Base.ts
+++ b/src/Base.ts
@@ -172,8 +172,8 @@ export class Instrumentation {
                 case Function.prototype.apply.name:
                 case Function.prototype.bind.name:
                     // Call, apply, and bind are external 
-                    // only if the base is external
-                    isExternal = IM.isExternalModule(base);
+                    // only if the base is external or native function
+                    isExternal = (typeof base === "function" && F.isNativeFunction(base)) || IM.isExternalModule(base);
                     break;
                 default:
                     break;

--- a/tests/unit_jalangi/tests/native_functions.ts
+++ b/tests/unit_jalangi/tests/native_functions.ts
@@ -1,7 +1,7 @@
 import { __jalangi_assert_taint_true__, __jalangi_assert_taint_false__, 
     __jalangi_set_taint__, __jalangi_set_prop_taint__, __jalangi_assert_prop_taint_false__,
     __jalangi_assert_prop_taint_true__} from "../../taint_header";
-import { test_suite, test_one } from "../../test_header";
+import { test_suite, test_one, test_assert } from "../../test_header";
 
 
 test_suite("---------- parseInt --------", function() {
@@ -57,5 +57,37 @@ test_suite("---------- isNaN --------", function() {
 
     test_one("isNaN(a) should be tainted", function () {
         __jalangi_assert_taint_true__(b);
+    });
+});
+
+test_suite("---------- call/apply/bind --------", function() {
+    let a = 2;
+
+    test_one("Setting taint on a", function() {
+        __jalangi_set_taint__(a);
+    });
+
+    let t1 = Object.prototype.toString.call(a);
+
+    // With fix, correctly returns '[object Number]'
+    // Without fix, would return '[object Object]'
+    test_one("toString.call(a) should return [object Number]", function () {
+        test_assert(t1 === '[object Number]');
+    });
+
+    let t2 = Object.prototype.toString.apply(a);
+
+    // With fix, correctly returns '[object Number]'
+    // Without fix, would return '[object Object]'
+    test_one("toString.apply(a) should return [object Number]", function () {
+        test_assert(t2 === '[object Number]');
+    });
+
+    let t3 = Object.prototype.toString.bind(a)();
+
+    // With fix, correctly returns '[object Number]'
+    // Without fix, would return '[object Object]'
+    test_one("toString.bind(a)() should return [object Number]", function () {
+        test_assert(t3 === '[object Number]');
     });
 });


### PR DESCRIPTION
In `src/Base.ts`, `invokeFunPre` sets `isExternal = IM.isExternalModule(base)` if the invoked function is `call`/`apply`/`bind` (ll. 171-178). The `IM.isExternalModule(base)` function looks for an `isExternalModule` flag in `base` that is set to true when an external module is imported. This fails to take into account cases where `base` is a native function, e.g., in `Object.prototype.toString.call(...)`, and may lead to errors when analyzing the function.

This fix adds a case for when `base` is a native function. In the `Object.prototype.toString.call(...)` example, the `isExternal` flag is now set to true, and NodeMedic executes the function correctly.