### PR TITLE
Fix external functions not propagating taint

### DIFF
--- a/src/Base.ts
+++ b/src/Base.ts
@@ -1,5 +1,5 @@
 import * as underscore from 'underscore';
-import { F, Literal, NativeFunction } from './Flib';
+import { F, Literal, ExternalFunction } from './Flib';
 import { State, describeState, Context, initState, setC, IID, 
          setTc, createTc, getTc, createTcFromSourceLocation } from './State';
 import { WLiteral, WGetFieldPre, WGetField, WInvokeFunPre,
@@ -275,10 +275,10 @@ export class Instrumentation {
         let baseP: Wrapped = res[1];
         let argsP: Wrapped[] = res[2];
         let resultP: Wrapped = res[3];
-        if (isNative) {
-            var s3 = F.eitherThrow(TCall(s2, fP as NativeFunction, baseP, argsP, resultP, isNative));
+        if (isExternal) {
+            var s3 = F.eitherThrow(TCall(s2, fP as ExternalFunction, baseP, argsP, resultP, isExternal));
         } else {
-            var s3 = F.eitherThrow(TCall(s2, fP as Function, baseP, argsP, resultP, isNative));
+            var s3 = F.eitherThrow(TCall(s2, fP as Function, baseP, argsP, resultP, isExternal));
         }
         let s4 = setC(s3, Context.Unset);
         this.s = s4;

--- a/src/Flib.ts
+++ b/src/Flib.ts
@@ -16,6 +16,7 @@ import { inspect } from 'util';
 export type Primitive = number | string | boolean | symbol;
 export type Literal = Primitive | Function;
 export type NativeFunction = Function;
+export type ExternalFunction = Function;
 
 export interface Maybe<A> {
     value: A | symbol,

--- a/src/Taint.ts
+++ b/src/Taint.ts
@@ -1,4 +1,4 @@
-import { F, Either, Literal, NativeFunction, Maybe } from './Flib';
+import { F, Either, Literal, Maybe, ExternalFunction } from './Flib';
 import { State, ID, PropMap, taintEntry, setMt, setPath, getTc } from './State';
 import { emptyPathNode, newPathNode, describePath, circularReplacer } from './TaintPaths';
 import { Wrapped } from './Wrapper';
@@ -373,14 +373,14 @@ export function TUnary(s: State, v1: Object, v2: Object): Either<State, Error> {
 
 export function TCall(
     s: State,
-    f: NativeFunction, 
+    f: ExternalFunction, 
     base: Object, 
     args: Object[], 
     result: Object, 
-    isNative: boolean
+    isExternal: boolean
 ): Either<State, Error> {
     // We only propagate taint via policies for native fns with a result
-    if (isNative && result !== undefined) {
+    if (isExternal && result !== undefined) {
         let ubase = getValue(s, base);
         return getPolicy(ubase).TCall(s, f, base, args, result);
     } else {

--- a/src/modules/Global.ts
+++ b/src/modules/Global.ts
@@ -9,9 +9,9 @@ import { getObjectPolicy } from './PolicyManager';
 
 export const GlobalPolicy: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {},
+    externalMethodWrapperPolicies: {},
 
-    nativeMethodTaintPolicies: {},
+    externalMethodTaintPolicies: {},
 
     isTainted(s: State, v: Wrapped) {
         const tE = F.eitherThrow(getTaintEntry(s, v));

--- a/src/modules/Global.ts
+++ b/src/modules/Global.ts
@@ -1,7 +1,7 @@
 import { modulePolicy } from './PolicyInterface';
 import { State } from '../State';
 import { Wrapped, Unwrapped } from '../Wrapper';
-import { F, Either, NativeFunction } from '../Flib';
+import { F, Either, ExternalFunction } from '../Flib';
 import { imprecisePolicy } from './Object';
 import { getTaintEntry, getValue } from '../Taint';
 import { getObjectPolicy } from './PolicyManager';
@@ -66,7 +66,7 @@ export const GlobalPolicy: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped

--- a/src/modules/List.ts
+++ b/src/modules/List.ts
@@ -11,8 +11,8 @@ import { getObjectPolicy } from './PolicyManager';
 
 export const ListPolicyImprecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {},
-    nativeMethodTaintPolicies: {
+    externalMethodWrapperPolicies: {},
+    externalMethodTaintPolicies: {
         'push': arrayPush,
     },
 
@@ -81,7 +81,7 @@ export const ListPolicyImprecise: modulePolicy = {
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Array, `Base ${base} is not an array`);
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
@@ -91,8 +91,8 @@ export const ListPolicyImprecise: modulePolicy = {
 
 export const ListPolicyPrecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {},
-    nativeMethodTaintPolicies: {
+    externalMethodWrapperPolicies: {},
+    externalMethodTaintPolicies: {
         'join': arrayJoin,
         'map': arrayMap,
         'reduce': arrayReduce,
@@ -159,7 +159,7 @@ export const ListPolicyPrecise: modulePolicy = {
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)

--- a/src/modules/List.ts
+++ b/src/modules/List.ts
@@ -1,7 +1,7 @@
-import { modulePolicy, nativeMethodTaintPolicyDispatch, NativeMethodTaintPolicy } from './PolicyInterface';
+import { modulePolicy, externalMethodTaintPolicyDispatch, ExternalMethodTaintPolicy } from './PolicyInterface';
 import { State, taintEntry, ID, setMt, setPath, getTc } from '../State';
 import { Wrapped, Unwrapped, unwrap, wrap } from '../Wrapper';
-import { F, Either, NativeFunction } from '../Flib';
+import { F, Either, NativeFunction, ExternalFunction } from '../Flib';
 import { getTaintEntry, getValue, setPropTaint, getPropTaint, oid,
          initPropMap, isTainted, anyPropertiesTainted } from '../Taint';
 import { SafeMap } from '../DataStructures';
@@ -75,14 +75,14 @@ export const ListPolicyImprecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Array, `Base ${base} is not an array`);
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });
@@ -154,13 +154,13 @@ export const ListPolicyPrecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });

--- a/src/modules/Lodash.ts
+++ b/src/modules/Lodash.ts
@@ -7,7 +7,7 @@ import { getObjectPolicy } from './PolicyManager';
 
 export const LodashPolicy: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {
+    externalMethodWrapperPolicies: {
         'each': {
             pre: F.Just(eachWrapPre),
             post: F.Nothing(),
@@ -18,7 +18,7 @@ export const LodashPolicy: modulePolicy = {
         },
     },
 
-    nativeMethodTaintPolicies: {},
+    externalMethodTaintPolicies: {},
 
     // Not used
     isTainted(s: State, v: Wrapped) { return true },
@@ -40,7 +40,7 @@ export const LodashPolicy: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Wrapped, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
             Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f as Function, base, args)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFunPre(s, f, base, args),
@@ -74,7 +74,7 @@ export const LodashPolicy: modulePolicy = {
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)

--- a/src/modules/Map.ts
+++ b/src/modules/Map.ts
@@ -13,8 +13,8 @@ import { getObjectPolicy } from './PolicyManager';
 
 export const MapPolicyImprecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {},
-    nativeMethodTaintPolicies: {
+    externalMethodWrapperPolicies: {},
+    externalMethodTaintPolicies: {
         'set': mapSetImprecisePolicy,
         'get': mapGetImprecisePolicy,
     },
@@ -82,7 +82,7 @@ export const MapPolicyImprecise: modulePolicy = {
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Map, `Base ${base} is not an map`);
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
@@ -167,14 +167,14 @@ function mapGetImprecisePolicy(
 
 export const MapPolicyPrecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {
+    externalMethodWrapperPolicies: {
         'set': {
             pre: F.Just(setWrapPre),
             post: F.Nothing(),
         },
     },
 
-    nativeMethodTaintPolicies: {
+    externalMethodTaintPolicies: {
         'set': mapSetPrecisePolicy,
         'get': mapGetPrecisePolicy,
     },
@@ -209,7 +209,7 @@ export const MapPolicyPrecise: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Wrapped, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
             Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f as Function, base, args)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFunPre(s, f, base, args),
@@ -217,7 +217,7 @@ export const MapPolicyPrecise: modulePolicy = {
     },
 
     WInvokeFun(s: State, f: any, base: any, args: any[], result: any): [State, any, any[], any] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f, WrapperPolicyType.post), {
             Just: (policy: ExternalMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFun(s, f, base, args, result),
@@ -248,7 +248,7 @@ export const MapPolicyPrecise: modulePolicy = {
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Map, `Base ${base} is not an map`);
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)

--- a/src/modules/Map.ts
+++ b/src/modules/Map.ts
@@ -1,9 +1,9 @@
-import { modulePolicy, NativeMethodTaintPolicy, nativeMethodTaintPolicyDispatch, 
-         nativeMethodWrapperPolicyDispatch, NativeMethodWrapPrePolicy, 
-         WrapperPolicyType, NativeMethodWrapPostPolicy } from './PolicyInterface';
+import { modulePolicy, ExternalMethodTaintPolicy, externalMethodTaintPolicyDispatch, 
+         externalMethodWrapperPolicyDispatch, ExternalMethodWrapPrePolicy, 
+         WrapperPolicyType, ExternalMethodWrapPostPolicy } from './PolicyInterface';
 import { State, taintEntry, ID, setMt, setPath, getTc } from '../State';
 import { Wrapped, Unwrapped, unwrap, wrap } from '../Wrapper';
-import { F, Either, NativeFunction } from '../Flib';
+import { F, Either, NativeFunction, ExternalFunction } from '../Flib';
 import { getTaintEntry, getValue, setPropTaint, getPropTaint, oid,
          initPropMap, isTainted, anyPropertiesTainted } from '../Taint';
 import { SafeMap } from '../DataStructures';
@@ -76,14 +76,14 @@ export const MapPolicyImprecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Map, `Base ${base} is not an map`);
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });
@@ -209,16 +209,16 @@ export const MapPolicyPrecise: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Wrapped, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(nativeMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, (f as Function), WrapperPolicyType.pre), {
-            Just: (policy: NativeMethodWrapPrePolicy) => F.eitherThrow(policy(s, (f as Function), base, args)),
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
+            Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f as Function, base, args)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFunPre(s, f, base, args),
         });
     },
 
     WInvokeFun(s: State, f: any, base: any, args: any[], result: any): [State, any, any[], any] {
-        return F.matchMaybe(nativeMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
-            Just: (policy: NativeMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
+            Just: (policy: ExternalMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFun(s, f, base, args, result),
         });
@@ -242,14 +242,14 @@ export const MapPolicyPrecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Map, `Base ${base} is not an map`);
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });

--- a/src/modules/Object.ts
+++ b/src/modules/Object.ts
@@ -64,14 +64,14 @@ function wrapObject(
 
 export const ObjectPolicy: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {
+    externalMethodWrapperPolicies: {
         'defineProperty': {
             pre: F.Just(definePropertyWrapPre),
             post: F.Nothing(),
         },
     },
 
-    nativeMethodTaintPolicies: {},
+    externalMethodTaintPolicies: {},
 
     isTainted(s: State, v: Wrapped) {
         const tE = F.eitherThrow(getTaintEntry(s, v));
@@ -98,7 +98,7 @@ export const ObjectPolicy: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Function, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.pre), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f, WrapperPolicyType.pre), {
             Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f, base, args)),
             // Fall back to ObjectPolicy
             Nothing: () => {
@@ -124,7 +124,7 @@ export const ObjectPolicy: modulePolicy = {
     },
 
     WInvokeFun(s: State, f: Function, base: any, args: any[], result: any): [State, any, any[], any] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f, WrapperPolicyType.post), {
             Just: (policy: ExternalMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
             // Fall back to ObjectPolicy
             Nothing: () => {
@@ -275,14 +275,14 @@ export const ObjectPolicy: modulePolicy = {
 
 export const ObjectPolicyImprecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {
+    externalMethodWrapperPolicies: {
         'defineProperty': {
             pre: F.Just(definePropertyWrapPre),
             post: F.Nothing(),
         },
     },
 
-    nativeMethodTaintPolicies: {},
+    externalMethodTaintPolicies: {},
 
     isTainted(s: State, v: Wrapped) {
         const tE = F.eitherThrow(getTaintEntry(s, v));

--- a/src/modules/Object.ts
+++ b/src/modules/Object.ts
@@ -1,8 +1,8 @@
-import { modulePolicy, nativeMethodWrapperPolicyDispatch, NativeMethodWrapPrePolicy,
-         NativeMethodWrapPostPolicy, WrapperPolicyType } from './PolicyInterface';
+import { modulePolicy, externalMethodWrapperPolicyDispatch, ExternalMethodWrapPrePolicy,
+         ExternalMethodWrapPostPolicy, WrapperPolicyType } from './PolicyInterface';
 import { State, taintEntry, ID, setMt, setIDS, taintTree, setTaintTreeMap, getTaintTreeMap, getTc } from '../State';
 import { Wrapped, Unwrapped, unwrap, wrap, getID } from '../Wrapper';
-import { F, Either, Maybe, NativeFunction } from '../Flib';
+import { F, Either, Maybe, NativeFunction, ExternalFunction } from '../Flib';
 import { getTaintEntry, oid, initPropMap, allPropertiesTainted, getValue, anyPropertiesTainted } from '../Taint';
 import { SafeMap } from '../DataStructures';
 import { PathNode, newPathNode, joinTEPaths, describePath, emptyPathNode } from '../TaintPaths';
@@ -98,8 +98,8 @@ export const ObjectPolicy: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Function, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(nativeMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.pre), {
-            Just: (policy: NativeMethodWrapPrePolicy) => F.eitherThrow(policy(s, f, base, args)),
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.pre), {
+            Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f, base, args)),
             // Fall back to ObjectPolicy
             Nothing: () => {
                 // Unwrap the arguments
@@ -124,8 +124,8 @@ export const ObjectPolicy: modulePolicy = {
     },
 
     WInvokeFun(s: State, f: Function, base: any, args: any[], result: any): [State, any, any[], any] {
-        return F.matchMaybe(nativeMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
-            Just: (policy: NativeMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
+            Just: (policy: ExternalMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
             // Fall back to ObjectPolicy
             Nothing: () => {
                 // Wrap the arguments
@@ -256,7 +256,7 @@ export const ObjectPolicy: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
@@ -413,7 +413,7 @@ export const ObjectPolicyImprecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped

--- a/src/modules/PolicyInterface.ts
+++ b/src/modules/PolicyInterface.ts
@@ -4,8 +4,8 @@ import { Either, ExternalFunction, Maybe, F } from '../Flib';
 
 
 export interface modulePolicy {
-    nativeMethodWrapperPolicies: Object,
-    nativeMethodTaintPolicies: Object,
+    externalMethodWrapperPolicies: Object,
+    externalMethodTaintPolicies: Object,
 
     isTainted(s: State, value: Wrapped): boolean,
 

--- a/src/modules/PolicyInterface.ts
+++ b/src/modules/PolicyInterface.ts
@@ -1,6 +1,6 @@
 import { State } from '../State';
 import { Wrapped, Unwrapped } from '../Wrapper';
-import { Either, NativeFunction, Maybe, F } from '../Flib';
+import { Either, ExternalFunction, Maybe, F } from '../Flib';
 
 
 export interface modulePolicy {
@@ -29,19 +29,19 @@ export interface modulePolicy {
 
     TUnary(s: State, v1: Wrapped, v2: Wrapped): Either<State, Error>,
 
-    TCall(s: State, f: NativeFunction, base: Wrapped, args: Wrapped[], result: Wrapped): Either<State, Error>,
+    TCall(s: State, f: ExternalFunction, base: Wrapped, args: Wrapped[], result: Wrapped): Either<State, Error>,
 }
 
-export type NativeMethodWrapPrePolicy = (
+export type ExternalMethodWrapPrePolicy = (
     s: State,
-    f: NativeFunction,
+    f: ExternalFunction,
     base: Wrapped,
     args: Wrapped[],
 ) => Either<[State, any, any[]], Error>;
 
-export type NativeMethodWrapPostPolicy = (
+export type ExternalMethodWrapPostPolicy = (
     s: State,
-    f: NativeFunction,
+    f: ExternalFunction,
     base: any,
     args: any[],
     result: any,
@@ -52,17 +52,17 @@ export enum WrapperPolicyType {
     post,
 }
 
-export function nativeMethodWrapperPolicyDispatch(
+export function externalMethodWrapperPolicyDispatch(
     policies: any, 
-    f: NativeFunction,
+    f: ExternalFunction,
     policyType: WrapperPolicyType,
-): Maybe<NativeMethodWrapPrePolicy | NativeMethodWrapPostPolicy> {
+): Maybe<ExternalMethodWrapPrePolicy | ExternalMethodWrapPostPolicy> {
     if (policies.hasOwnProperty(f.name)) {
         // Apply one of our models
         if (policyType == WrapperPolicyType.pre) {
-            return policies[f.name].pre as Maybe<NativeMethodWrapPrePolicy>;
+            return policies[f.name].pre as Maybe<ExternalMethodWrapPrePolicy>;
         } else if (policyType == WrapperPolicyType.post) {
-            return policies[f.name].post as Maybe<NativeMethodWrapPostPolicy>;
+            return policies[f.name].post as Maybe<ExternalMethodWrapPostPolicy>;
         } else {
             F.unreachable(`Unhandled policyType: ${policyType}`);
         }
@@ -71,21 +71,21 @@ export function nativeMethodWrapperPolicyDispatch(
     }
 }
 
-export type NativeMethodTaintPolicy = (
+export type ExternalMethodTaintPolicy = (
     s: State,
-    f: NativeFunction,
+    f: ExternalFunction,
     base: Wrapped,
     args: Wrapped[],
     result: Wrapped,
 ) => Either<State, Error>;
 
-export function nativeMethodTaintPolicyDispatch(
+export function externalMethodTaintPolicyDispatch(
     policies: any, 
-    f: NativeFunction
-): Maybe<NativeMethodTaintPolicy> {
+    f: ExternalFunction
+): Maybe<ExternalMethodTaintPolicy> {
     if (policies.hasOwnProperty(f.name)) {
         // Apply one of our models
-        return F.Just(policies[f.name] as NativeMethodTaintPolicy);
+        return F.Just(policies[f.name] as ExternalMethodTaintPolicy);
     } else {
         return F.Nothing();
     }

--- a/src/modules/Set.ts
+++ b/src/modules/Set.ts
@@ -1,9 +1,9 @@
-import { modulePolicy, NativeMethodTaintPolicy, nativeMethodTaintPolicyDispatch, 
-         nativeMethodWrapperPolicyDispatch, NativeMethodWrapPrePolicy, 
-         WrapperPolicyType, NativeMethodWrapPostPolicy } from './PolicyInterface';
+import { modulePolicy, ExternalMethodTaintPolicy, externalMethodTaintPolicyDispatch, 
+         externalMethodWrapperPolicyDispatch, ExternalMethodWrapPrePolicy, 
+         WrapperPolicyType, ExternalMethodWrapPostPolicy } from './PolicyInterface';
 import { State, taintEntry, ID, setMt, setPath, getTc } from '../State';
 import { Wrapped, Unwrapped, unwrap, wrap } from '../Wrapper';
-import { F, Either, NativeFunction } from '../Flib';
+import { F, Either, NativeFunction, ExternalFunction } from '../Flib';
 import { getTaintEntry, getValue, setPropTaint, getPropTaint, oid,
          initPropMap, isTainted, anyPropertiesTainted } from '../Taint';
 import { SafeMap } from '../DataStructures';
@@ -81,14 +81,14 @@ export const SetPolicyImprecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Set, `Base ${base} is not an set`);
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });
@@ -208,16 +208,16 @@ export const SetPolicyPrecise: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Wrapped, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(nativeMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, (f as Function), WrapperPolicyType.pre), {
-            Just: (policy: NativeMethodWrapPrePolicy) => F.eitherThrow(policy(s, (f as Function), base, args)),
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
+            Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f as Function, base, args)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFunPre(s, f, base, args),
         });
     },
 
     WInvokeFun(s: State, f: any, base: any, args: any[], result: any): [State, any, any[], any] {
-        return F.matchMaybe(nativeMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
-            Just: (policy: NativeMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
+            Just: (policy: ExternalMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFun(s, f, base, args, result),
         });
@@ -241,14 +241,14 @@ export const SetPolicyPrecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Set, `Base ${base} is not an set`);
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });

--- a/src/modules/Set.ts
+++ b/src/modules/Set.ts
@@ -13,8 +13,8 @@ import { getObjectPolicy } from './PolicyManager';
 
 export const SetPolicyImprecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {},
-    nativeMethodTaintPolicies: {
+    externalMethodWrapperPolicies: {},
+    externalMethodTaintPolicies: {
         'add': setAddImprecisePolicy,
         'values': setValuesImprecisePolicy,
     },
@@ -87,7 +87,7 @@ export const SetPolicyImprecise: modulePolicy = {
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Set, `Base ${base} is not an set`);
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
@@ -161,14 +161,14 @@ function setValuesImprecisePolicy(
 
 export const SetPolicyPrecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {
+    externalMethodWrapperPolicies: {
         'add': {
             pre: F.Just(addWrapPre),
             post: F.Nothing(),
         },
     },
 
-    nativeMethodTaintPolicies: {
+    externalMethodTaintPolicies: {
         'add': setAddPrecisePolicy,
         'values': setValuesPrecisePolicy,
     },
@@ -208,7 +208,7 @@ export const SetPolicyPrecise: modulePolicy = {
     },
 
     WInvokeFunPre(s: State, f: Wrapped, base: Wrapped, args: Wrapped[]): [State, any, any[]] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f as Function, WrapperPolicyType.pre), {
             Just: (policy: ExternalMethodWrapPrePolicy) => F.eitherThrow(policy(s, f as Function, base, args)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFunPre(s, f, base, args),
@@ -216,7 +216,7 @@ export const SetPolicyPrecise: modulePolicy = {
     },
 
     WInvokeFun(s: State, f: any, base: any, args: any[], result: any): [State, any, any[], any] {
-        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.nativeMethodWrapperPolicies, f, WrapperPolicyType.post), {
+        return F.matchMaybe(externalMethodWrapperPolicyDispatch(this.externalMethodWrapperPolicies, f, WrapperPolicyType.post), {
             Just: (policy: ExternalMethodWrapPostPolicy) => F.eitherThrow(policy(s, f, base, args, result)),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().WInvokeFun(s, f, base, args, result),
@@ -247,7 +247,7 @@ export const SetPolicyPrecise: modulePolicy = {
         result: Wrapped
     ): Either<State, Error> {
         F.assert(getValue(s, base) instanceof Set, `Base ${base} is not an set`);
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)

--- a/src/modules/String.ts
+++ b/src/modules/String.ts
@@ -12,9 +12,9 @@ import { getObjectPolicy, policyPrecisionMap } from './PolicyManager';
 
 export const StringPolicyPrecise: modulePolicy = {
 
-    nativeMethodWrapperPolicies: {},
+    externalMethodWrapperPolicies: {},
 
-    nativeMethodTaintPolicies: {
+    externalMethodTaintPolicies: {
         "blink": stringBlink,
         "substring": stringSubstring,
         "concat": stringConcat,
@@ -161,7 +161,7 @@ export const StringPolicyPrecise: modulePolicy = {
                 // Fall back to module policies or imprecise policy
             }
         }
-        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.externalMethodTaintPolicies, f), {
             Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)

--- a/src/modules/String.ts
+++ b/src/modules/String.ts
@@ -1,8 +1,8 @@
-import { modulePolicy, nativeMethodTaintPolicyDispatch, NativeMethodTaintPolicy } from './PolicyInterface';
+import { modulePolicy, externalMethodTaintPolicyDispatch, ExternalMethodTaintPolicy } from './PolicyInterface';
 import { State, taintEntry, PropMap, ID, setMt, setPath, getTc } from '../State';
 import { newPathNode, PathNode, joinTEPaths, emptyPathNode } from '../TaintPaths';
 import { Wrapped, Unwrapped } from '../Wrapper';
-import { F, Either, Literal, NativeFunction } from '../Flib';
+import { F, Either, Literal, NativeFunction, ExternalFunction } from '../Flib';
 import { getTaintEntry, getValue, oid, initPropMap,
          setPropTaint, getPropTaint, anyPropertiesTainted } from '../Taint';
 import { SafeMap } from '../DataStructures';
@@ -126,7 +126,7 @@ export const StringPolicyPrecise: modulePolicy = {
 
     TCall(
         s: State, 
-        f: NativeFunction, 
+        f: ExternalFunction, 
         base: Wrapped, 
         args: Wrapped[], 
         result: Wrapped
@@ -161,8 +161,8 @@ export const StringPolicyPrecise: modulePolicy = {
                 // Fall back to module policies or imprecise policy
             }
         }
-        return F.matchMaybe(nativeMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
-            Just: (policy: NativeMethodTaintPolicy) => policy(s, f, base, args, result),
+        return F.matchMaybe(externalMethodTaintPolicyDispatch(this.nativeMethodTaintPolicies, f), {
+            Just: (policy: ExternalMethodTaintPolicy) => policy(s, f as NativeFunction, base, args, result),
             // Fall back to Object policy
             Nothing: () => getObjectPolicy().TCall(s, f, base, args, result)
         });

--- a/tests/unit_jalangi/tests/external_functions.ts
+++ b/tests/unit_jalangi/tests/external_functions.ts
@@ -1,0 +1,19 @@
+import { __jalangi_assert_taint_true__, __jalangi_assert_taint_false__, 
+    __jalangi_set_taint__, __jalangi_set_prop_taint__, __jalangi_assert_prop_taint_false__,
+    __jalangi_assert_prop_taint_true__} from "../../taint_header";
+import { test_suite, test_one } from "../../test_header";
+import { basename } from 'path';
+
+test_suite("---------- External function --------", function() {
+    var a = '/a/b/c.d';
+
+    test_one("Setting taint on a", function() {
+        __jalangi_set_taint__(a);
+    });
+
+    let b = basename(a);
+
+    test_one("path.basename(a) should be tainted", function () {
+        __jalangi_assert_taint_true__(b);
+    });
+});


### PR DESCRIPTION
NodeMedic-FINE has a mechanism to over-approximate the analysis of uninstrumented (external) functions: if such a function is called with tainted arguments, then the result is also tainted. This should apply to all external functions (S3.3, paragraph "Over-approximated function analysis" in the original NodeMedic paper), but in the implementation only works for native functions. This can lead to losing taint in calls to non-native Node.js core modules (e.g., `path`, `fs`) or packages annotated with `// JALANGI DO NOT INSTRUMENT`.

This fix changes the over-approximated function call policy to also apply to non-native external functions. A new unit test showcasing this is included (`external_functions.ts`). In the test, a call to the `path` function `basename` should return a tainted value if it's called on a tainted argument. With the fix, this test passes; without it, it loses taint.