### PR TITLE
Debian buster reached EOL so use bookworn with node20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Node.js v15.5.0
 # Debian Buster
-FROM node:15.5.0-buster
+FROM node:20-bookworm
 
 # Set up the working directory
 WORKDIR /nodetaint
@@ -20,14 +20,14 @@ RUN wget https://github.com/sharkdp/hyperfine/releases/download/v1.11.0/hyperfin
 RUN dpkg -i hyperfine_1.11.0_amd64.deb
 
 # Set up node environment
-RUN npm i -g n typescript 
+RUN npm i -g n typescript
 
 # Set up python environment
 RUN apt-get install -y make build-essential
 RUN apt-get --allow-releaseinfo-change update
 RUN apt-get install -y libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev \
-    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 RUN curl https://pyenv.run | bash
 RUN echo 'export PATH="/root/.pyenv/bin:$PATH"' >> /root/.bashrc
 RUN echo 'eval "$(pyenv init -)"' >> /root/.bashrc
@@ -36,7 +36,7 @@ ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 ENV PYTHON_VERSION=3.11.4
 RUN pyenv install ${PYTHON_VERSION}
-RUN pyenv global ${PYTHON_VERSION} 
+RUN pyenv global ${PYTHON_VERSION}
 
 # Copy over files
 COPY lib ./lib


### PR DESCRIPTION
Should be good until 2028

### Reason for the change

It wasn't building:

```sh
 => ERROR [ 3/32] RUN apt-get -qq update;     apt-get install -qqy bash make vim git graphviz                                                                                                                                    0.5s
------
 > [ 3/32] RUN apt-get -qq update;     apt-get install -qqy bash make vim git graphviz:
0.460 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
0.460 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.460 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
0.487 E: Unable to locate package vim
0.487 E: Package 'graphviz' has no installation candidate
------
Dockerfile:9
--------------------
   8 |     # Install essential packages
   9 | >>> RUN apt-get -qq update; \
  10 | >>>     apt-get install -qqy bash make vim git graphviz
  11 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get -qq update;     apt-get install -qqy bash make vim git graphviz" did not complete successfully: exit code: 10
```